### PR TITLE
Analyze emo_style for dragged selection

### DIFF
--- a/model/emosphere.py
+++ b/model/emosphere.py
@@ -63,7 +63,7 @@ class EmoSphere(nn.Module):
                 n_emotion,
                 model_config["transformer"]["encoder_hidden"],
             )
-        # Sphere
+        # Sphere - 전체 구 지원
         self.hidden_size = model_config["transformer"]["encoder_hidden"]
 
         self.use_spk_lookup = use_spk_lookup
@@ -81,14 +81,15 @@ class EmoSphere(nn.Module):
             self.hidden_size // 4, self.hidden_size // 4, bias=True
         )
 
+        # 전체 구 범위로 확장
         self.azimuth_bins = nn.Parameter(
-            torch.linspace(-np.pi / 2, np.pi, 4), requires_grad=False
+            torch.linspace(-np.pi, np.pi, 8), requires_grad=False  # -180° ~ 180° (전체 360도)
         )
-        self.azimuth_emb = Embedding(4, self.hidden_size // 8)
+        self.azimuth_emb = Embedding(8, self.hidden_size // 8)  # 4 -> 8개로 증가
         self.elevation_bins = nn.Parameter(
-            torch.linspace(np.pi / 2, np.pi, 2), requires_grad=False
+            torch.linspace(0, np.pi, 4), requires_grad=False  # 0° ~ 180° (전체 구)
         )
-        self.elevation_emb = Embedding(2, self.hidden_size // 8)
+        self.elevation_emb = Embedding(4, self.hidden_size // 8)  # 2 -> 4개로 증가
 
         self.emo_proj = nn.Linear(
             self.hidden_size // 4, self.hidden_size // 4, bias=True


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Extend spherical coordinate bins in `emosphere.py` to cover the full sphere to resolve a training-inference mismatch.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, the model was trained only on the lower hemisphere of the VAD space (`elevation_bins` from π/2 to π), but inference (e.g., for "Happy/Joy" at elevation π/4) used coordinates outside this trained range. This led to out-of-distribution issues and potential inaccuracies for emotions in the upper hemisphere. This change expands the `elevation_bins` to cover 0 to π and `azimuth_bins` to -π to π, ensuring the model can properly learn and infer emotions across the entire spherical VAD space.

---
<a href="https://cursor.com/background-agent?bcId=bc-15d63304-3786-463d-88b3-334fea5944fd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-15d63304-3786-463d-88b3-334fea5944fd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>